### PR TITLE
Add configuration settings for `ruff`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,6 @@
 {
     "python.linting.mypyEnabled": true,
     "python.linting.enabled": true,
-    "python.formatting.provider": "none",
     "editor.formatOnSave": true,
     "editor.rulers": [
         88
@@ -24,5 +23,6 @@
             "source.fixAll.ruff": true,
             "source.organizeImports.ruff": true
         }
-    }
+    },
+    "python.formatting.provider": "black"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,20 @@ ruff = "^0.0.278"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+ignore = [
+    "D104",
+    "D107",
+    "D202",
+]
+line-length = 88
+select = [
+    "D",
+    "E",
+    "F",
+    "W",
+]
+
+[tool.ruff.pydocstyle]
+convention = "google"

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,3 +24,19 @@ disallow_untyped_calls = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
+[tool.ruff]
+ignore = [
+    "D104",
+    "D107",
+    "D202",
+]
+line-length = 88
+select = [
+    "D",
+    "E",
+    "F",
+    "W",
+]
+
+[tool.ruff.pydocstyle]
+convention = "google"

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,20 +23,3 @@ ignore_errors = True
 disallow_untyped_calls = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
-
-[tool.ruff]
-ignore = [
-    "D104",
-    "D107",
-    "D202",
-]
-line-length = 88
-select = [
-    "D",
-    "E",
-    "F",
-    "W",
-]
-
-[tool.ruff.pydocstyle]
-convention = "google"


### PR DESCRIPTION
# Description

Forgot to actually add any settings for `ruff` This pull requests adds some sensible default settings (e.g. google style docstrings). These settings may well be changed down the line.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [N/A] Code is commented, particularly in hard-to-understand areas
- [N/A] Tests added that prove fix is effective or that feature works
